### PR TITLE
Refactor task creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
-    //id 'checkstyle'
+    id 'checkstyle'
 }
 
 repositories {
@@ -52,10 +52,11 @@ shadowJar {
     archiveClassifier = null
 }
 
-//checkstyle {
-    //toolVersion = '10.2'
-//}
+checkstyle {
+    toolVersion = '10.2'
+}
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/rose/Rose.java
+++ b/src/main/java/rose/Rose.java
@@ -70,9 +70,6 @@ public class Rose {
             return e.getMessage();
         }
     }
-    //public static void main(String... args) {
-        //new Rose().run();
-    //}
 }
 
 


### PR DESCRIPTION
The task creation logic in AddCommand is cluttered, which makes the code harder to read and maintain.

This needs to change to improve code readability, follow the SLAP, and ensure each method handles only one responsibility.

Refactor task creation into separate methods (createTodo, createDeadline, createEvent) to isolate the logic for each task type.

This approach improves clarity, simplifies future maintenance, and aligns with good object-oriented practices.